### PR TITLE
Added session timeout for inactivity

### DIFF
--- a/superset/app.py
+++ b/superset/app.py
@@ -20,7 +20,7 @@ import os
 from typing import Any, Callable, Dict
 
 import wtforms_json
-from flask import Flask, redirect
+from flask import Flask, redirect, request, session
 from flask_appbuilder import expose, IndexView
 from flask_babel import gettext as __, lazy_gettext as _
 from flask_compress import Compress
@@ -96,6 +96,15 @@ class SupersetAppInitializer:
         """
         Called after any other init tasks
         """
+        @self.flask_app.before_request
+        def session_refresh():
+            """
+            If request has a session and is not requesting for login.
+            Refresh their session timer by modifying the session
+            """
+            if request.path != appbuilder.get_url_for_login and session:
+                session.permanent = True
+                session.modified = True
 
     def configure_celery(self) -> None:
         celery_app.config_from_object(self.config["CELERY_CONFIG"])

--- a/superset/config.py
+++ b/superset/config.py
@@ -133,6 +133,9 @@ SUPERSET_WEBSERVER_PORT = 8088
 # (gunicorn, nginx, apache, ...) timeout setting to be <= to this setting
 SUPERSET_WEBSERVER_TIMEOUT = 60
 
+# Invalidate sessions that are older than 10 minutes
+PERMANENT_SESSION_LIFETIME = 600
+
 # this 2 settings are used by dashboard period force refresh feature
 # When user choose auto force refresh frequency
 # < SUPERSET_DASHBOARD_PERIODICAL_REFRESH_LIMIT


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Implements timeout of sessions that have been inactive for more than 10
minutes.

Timeout can be changed by modifying the PERMANENT_SESSION_LIFETIME
argument in superset/config.py

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
