### PR TITLE
Added POC for disabling multiple device login

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -45,6 +45,7 @@ from superset.typing import CacheConfig
 from superset.utils.core import is_test
 from superset.utils.log import DBEventLogger
 from superset.utils.logging_configurator import DefaultLoggingConfigurator
+from superset.custom_security_manager import CustomSecurityManager
 
 logger = logging.getLogger(__name__)
 
@@ -145,7 +146,7 @@ SUPERSET_DASHBOARD_PERIODICAL_REFRESH_LIMIT = 0
 SUPERSET_DASHBOARD_PERIODICAL_REFRESH_WARNING_MESSAGE = None
 
 SUPERSET_DASHBOARD_POSITION_DATA_LIMIT = 65535
-CUSTOM_SECURITY_MANAGER = None
+CUSTOM_SECURITY_MANAGER = CustomSecurityManager
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 # ---------------------------------------------------------
 

--- a/superset/custom_security_manager/__init__.py
+++ b/superset/custom_security_manager/__init__.py
@@ -1,0 +1,41 @@
+from flask import redirect, g, flash, request, session
+from flask_appbuilder.security.views import AuthView
+from superset.security import SupersetSecurityManager
+from flask_appbuilder.security.views import expose
+from flask_login import login_user
+from flask_appbuilder.security.forms import LoginForm_db
+
+class CustomAuthDBView(AuthView):
+   fake_redis = {}
+   login_template = "appbuilder/general/security/login_db.html"
+   @expose("/login/", methods=["GET", "POST"])
+   def login(self):
+       if g.user is not None and g.user.is_authenticated:
+           return redirect(self.appbuilder.get_url_for_index)
+       form = LoginForm_db()
+       if form.validate_on_submit():
+           user = self.appbuilder.sm.auth_user_db(
+               form.username.data, form.password.data
+           )
+           if not user:
+               flash(as_unicode(self.invalid_login_message), "warning")
+               return redirect(self.appbuilder.get_url_for_login)
+           login_user(user, remember=False)
+           self.fake_redis[int(session.get("user_id"))] = session.get("_id")
+           return redirect(self.appbuilder.get_url_for_index)
+       return self.render_template(
+           self.login_template, title=self.title, form=form, appbuilder=self.appbuilder
+       )
+
+class CustomSecurityManager(SupersetSecurityManager):
+   # Register the custom auth view
+   authdbview = CustomAuthDBView
+   # Override load user method
+   def load_user(self,pk):
+       # If its not the most recent login, user is logged out
+       if self.authdbview.fake_redis.get(int(pk), None) != session.get("_id"):
+           session.clear()
+           return None
+       return self.get_user_by_id(int(pk))
+   def __init__(self,appbuilder):
+       super(CustomSecurityManager, self).__init__(appbuilder)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Implementation is not thread safe and should not be used in production
environment. The implementation can be made thread safe by implementing
a key-store database to replace the fake_redis dictionary being used as
a placeholder

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
