### PR TITLE
[Outdated] Added redirect logic to auth errors

### DIFF
--- a/superset-frontend/src/utils/getClientErrorObject.ts
+++ b/superset-frontend/src/utils/getClientErrorObject.ts
@@ -34,6 +34,7 @@ export type ClientErrorObject = {
   message?: string;
   severity?: string;
   stacktrace?: string;
+  msg?:string;
 } & Partial<SupersetClientResponse>;
 
 interface ResponseWithTimeout extends Response {

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -166,6 +166,11 @@ export function createErrorHandler(
   return async (e: SupersetClientResponse | string) => {
     const parsedError = await getClientErrorObject(e);
     logging.error(e);
+
+    // Navigate to login page upon losing authorization
+    if (parsedError.msg?.toLowerCase().includes("missing authorization header")){
+      window.location.href = '/login';
+    }
     handleErrorFunc(parsedError.message || parsedError.error);
   };
 }


### PR DESCRIPTION


### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Redirects page to login when the "Missing Authorization Header" is
returned. This signifies the user has either timed out or been
unauthenticated due to multiple device login.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
